### PR TITLE
Fixed @align_x initialize error on linux

### DIFF
--- a/src/hedron/ui/grid.cr
+++ b/src/hedron/ui/grid.cr
@@ -10,7 +10,7 @@ module Hedron
     property align_x : Align
     property align_y : Align
 
-    def initialize(@size, @expand, @align); end
+    def initialize(@size, @expand, @align_x, @align_y); end
   end
 
   class Grid < Control


### PR DESCRIPTION
When compiling with Crystal 0.25.1, an error is returned since @align_x and @align_y aren't initialized. This fixes that.